### PR TITLE
2.1.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ services:
   - docker
 
 install:
-  - docker build -t blazegraph:1.5.3 1.5.3/
-  - docker run --name blazegraph -d -p 8080:8080 blazegraph:1.5.3
+  - docker build -t blazegraph:2.1.4 2.1.4/
+  - docker run --name blazegraph -d -p 8080:8080 blazegraph:2.1.4
 
 before_script:
   - sleep 30
@@ -17,4 +17,3 @@ before_script:
 script:
   - docker ps | grep blazegraph
   - curl http://localhost:8080/bigdata/#query
-

--- a/2.1.4/Dockerfile
+++ b/2.1.4/Dockerfile
@@ -1,14 +1,16 @@
-FROM openjdk:8-jre-alpine
+FROM jetty:9.4.2-jre8-alpine
 
 MAINTAINER kevin@enchartus.ca
 
 ENV JETTY_WEBAPPS /var/lib/jetty/webapps
 ENV BLAZEGRAPH_NAME bigdata
 ENV BLAZEGRAPH_RW_PATH /RWStore.properties
-ENV BLAZEGRAPH_VERSION 2.1.4
+ENV BLAZEGRAPH_VERSION 2_1_4
 ENV BLAZEGRAPH_VERSION_URL https://github.com/blazegraph/database/releases/download/BLAZEGRAPH_RELEASE_${BLAZEGRAPH_VERSION}/blazegraph.war
 
 ADD RWStore.properties $BLAZEGRAPH_RW_PATH
+
+RUN apk --no-cache add openssl
 
 RUN wget -O ${JETTY_WEBAPPS}/${BLAZEGRAPH_NAME}.war $BLAZEGRAPH_VERSION_URL
 RUN chown jetty:jetty $BLAZEGRAPH_RW_PATH

--- a/2.1.4/Dockerfile
+++ b/2.1.4/Dockerfile
@@ -1,0 +1,16 @@
+FROM openjdk:8-jre-alpine
+
+MAINTAINER kevin@enchartus.ca
+
+ENV JETTY_WEBAPPS /var/lib/jetty/webapps
+ENV BLAZEGRAPH_NAME bigdata
+ENV BLAZEGRAPH_RW_PATH /RWStore.properties
+ENV BLAZEGRAPH_VERSION 2.1.4
+ENV BLAZEGRAPH_VERSION_URL https://github.com/blazegraph/database/releases/download/BLAZEGRAPH_RELEASE_${BLAZEGRAPH_VERSION}/blazegraph.war
+
+ADD RWStore.properties $BLAZEGRAPH_RW_PATH
+
+RUN wget -O ${JETTY_WEBAPPS}/${BLAZEGRAPH_NAME}.war $BLAZEGRAPH_VERSION_URL
+RUN chown jetty:jetty $BLAZEGRAPH_RW_PATH
+
+CMD ["-Dcom.bigdata.rdf.sail.webapp.ConfigParams.propertyFile=/RWStore.properties"]

--- a/2.1.4/RWStore.properties
+++ b/2.1.4/RWStore.properties
@@ -1,0 +1,50 @@
+#
+# Note: These options are applied when the journal and the triple store are
+# first created.
+
+##
+## Journal options.
+##
+
+# The backing file. This contains all your data.  You want to put this someplace
+# safe.  The default locator will wind up in the directory from which you start
+# your servlet container.
+com.bigdata.journal.AbstractJournal.file=bigdata.jnl
+
+# The persistence engine.  Use 'Disk' for the WORM or 'DiskRW' for the RWStore.
+com.bigdata.journal.AbstractJournal.bufferMode=DiskRW
+
+# Setup for the RWStore recycler rather than session protection.
+com.bigdata.service.AbstractTransactionService.minReleaseAge=1
+
+# Enable group commit. See http://wiki.blazegraph.com/wiki/index.php/GroupCommit
+# Note: Group commit is a beta feature in BlazeGraph release 1.5.1.
+#com.bigdata.journal.Journal.groupCommit=true
+
+com.bigdata.btree.writeRetentionQueue.capacity=4000
+com.bigdata.btree.BTree.branchingFactor=128
+
+# 200M initial extent.
+com.bigdata.journal.AbstractJournal.initialExtent=209715200
+com.bigdata.journal.AbstractJournal.maximumExtent=209715200
+
+##
+## Setup for QUADS mode without the full text index.
+##
+com.bigdata.rdf.sail.truthMaintenance=false
+com.bigdata.rdf.store.AbstractTripleStore.quads=true
+com.bigdata.rdf.store.AbstractTripleStore.statementIdentifiers=false
+com.bigdata.rdf.store.AbstractTripleStore.textIndex=false
+com.bigdata.rdf.store.AbstractTripleStore.axiomsClass=com.bigdata.rdf.axioms.NoAxioms
+
+# Bump up the branching factor for the lexicon indices on the default kb.
+com.bigdata.namespace.kb.lex.com.bigdata.btree.BTree.branchingFactor=400
+
+# Bump up the branching factor for the statement indices on the default kb.
+com.bigdata.namespace.kb.spo.com.bigdata.btree.BTree.branchingFactor=1024
+
+# Uncomment to enable collection of OS level performance counters.  When
+# collected they will be self-reported through the /counters servlet and
+# the workbench "Performance" tab.
+#
+# com.bigdata.journal.Journal.collectPlatformStatistics=true

--- a/README.md
+++ b/README.md
@@ -1,23 +1,20 @@
 Docker Blazegraph
 =================
 
-[![](https://imagelayers.io/badge/lyrasis/blazegraph:1.5.3.svg)](https://imagelayers.io/?images=lyrasis/blazegraph:1.5.3 'Get your own badge on imagelayers.io')
-[![Build Status](https://travis-ci.org/lyrasis/docker-blazegraph.svg?branch=master)](https://travis-ci.org/lyrasis/docker-blazegraph)
-
 Run Blazegraph in Docker.
 
 **Quickstart**
 
 ```bash
-docker run --name blazegraph -d -p 8889:8080 lyrasis/blazegraph:1.5.3
+docker run --name blazegraph -d -p 8889:8080 superphy/blazegraph:2.1.4
 docker logs -f blazegraph
 ```
 
 **Local builds**
 
 ```
-docker build -t blazegraph:1.5.3 1.5.3/
-docker run --name blazegraph -d -p 8889:8080 blazegraph:1.5.3
+docker build -t blazegraph:2.1.4 2.1.4/
+docker run --name blazegraph -d -p 8889:8080 blazegraph:2.1.4
 docker logs -f blazegraph
 ```
 


### PR DESCRIPTION
An update to reference 2.1.4. Just some minor changes:
* Blazegraph moved releases to github. Now reflects this.
* Apline Linux based jetty image (smaller)

We should update it to lyrasis/blazegraph once the build is pushed Docker Hub.

Cats 🐱 