### PR TITLE
Update parameter order

### DIFF
--- a/2.1.5/Dockerfile
+++ b/2.1.5/Dockerfile
@@ -32,4 +32,4 @@ USER jetty
 # problem if rules.log is not found:
 # https://wiki.blazegraph.com/wiki/index.php/NanoSparqlServer#Common_Startup_Problems
 WORKDIR /var/lib/jetty
-CMD java $JAVA_OPTS -jar /usr/local/jetty/start.jar -Dcom.bigdata.rdf.sail.webapp.ConfigParams.propertyFile=/RWStore.properties
+CMD java $JAVA_OPTS -Dcom.bigdata.rdf.sail.webapp.ConfigParams.propertyFile=/RWStore.properties -jar /usr/local/jetty/start.jar


### PR DESCRIPTION
Parameters passed after the `-jar` flag are passed to the jar, not into java. We want to pass `com.bigdata.rdf.sail.webapp.ConfigParams.propertyFile` into java.

This was a mistake on my part, I had it right in the 2.1.4 `Dockerfile`.

I'm not sure it actually makes a difference, since either way Blazegraph gets the argument, but jetty does complain about it in the logs, so might as well pass it in this order.