### PR TITLE
Start blazegraph jetty as a user

### DIFF
--- a/2.1.5/Dockerfile
+++ b/2.1.5/Dockerfile
@@ -1,35 +1,26 @@
 FROM jetty:9-jre8-alpine
 
-LABEL authors="mark.cooper@lyrasis.org,kevin@enchartus.ca"
+LABEL authors="mark.cooper@lyrasis.org,jonathan.green@lyrasis.org"
 
 ENV BLAZEGRAPH_NAME=bigdata \
     BLAZEGRAPH_RW_PATH=/RWStore.properties \
     BLAZEGRAPH_VERSION=CANDIDATE_2_1_5 \
     JAVA_OPTS="-Xmx1g" \
-    JETTY_WEBAPPS=/var/lib/jetty/webapps
+    JETTY_WEBAPPS=/var/lib/jetty/webapps \
+    BLAZEGRAPH_UID=888 \
+    BLAZEGRAPH_GID=888
 ENV BLAZEGRAPH_VERSION_URL https://github.com/blazegraph/database/releases/download/BLAZEGRAPH_RELEASE_${BLAZEGRAPH_VERSION}/blazegraph.war
 
 ADD RWStore.properties $BLAZEGRAPH_RW_PATH
+ADD entrypoint.sh /var/lib/jetty/entrypoint.sh
 
 USER root
-RUN apk --no-cache add openssl
 
-# These are based on recommendations from the OpenShift docs in
-# https://docs.openshift.org/latest/creating_images/guidelines.html#use-uid
-# because of its use of random uids.
-RUN wget -O ${JETTY_WEBAPPS}/${BLAZEGRAPH_NAME}.war $BLAZEGRAPH_VERSION_URL && \
-    chown jetty:jetty $BLAZEGRAPH_RW_PATH && \
-    chgrp -R 0 /var/lib/jetty && \
-    chmod -R g=u /var/lib/jetty
+RUN apk add --no-cache openssl && \
+    apk add --no-cache bash && \
+    apk add --no-cache su-exec && \
+    wget -O ${JETTY_WEBAPPS}/${BLAZEGRAPH_NAME}.war $BLAZEGRAPH_VERSION_URL && \ 
+    chmod +x /var/lib/jetty/entrypoint.sh
 
-
-# We must not run as root, because of OpenShift policy
-USER jetty
-
-# We have to make sure we run in the correct folder, since that might be messed
-# up because of OpenShift's random uids (see the link above for more info).
-# The blazegraph docs also hint about wrong startup folder being a possible
-# problem if rules.log is not found:
-# https://wiki.blazegraph.com/wiki/index.php/NanoSparqlServer#Common_Startup_Problems
 WORKDIR /var/lib/jetty
-CMD java $JAVA_OPTS -Dcom.bigdata.rdf.sail.webapp.ConfigParams.propertyFile=/RWStore.properties -jar /usr/local/jetty/start.jar
+CMD ./entrypoint.sh

--- a/2.1.5/entrypoint.sh
+++ b/2.1.5/entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Create blazegraph user
+addgroup -S -g $BLAZEGRAPH_GID blazegraph
+adduser -S -s /bin/false -G blazegraph -u $BLAZEGRAPH_UID blazegraph
+
+# Make sure permissions are good
+chown -R blazegraph:blazegraph "$JETTY_BASE"
+chown -R blazegraph:blazegraph "$TMPDIR"
+
+su-exec blazegraph:blazegraph java $JAVA_OPTS -Dcom.bigdata.rdf.sail.webapp.ConfigParams.propertyFile=/RWStore.properties -jar /usr/local/jetty/start.jar


### PR DESCRIPTION
When I was trying to mount the data folder out of the container I was running into UID and GID conflicts. Allow the UID and GID to be configured by environment variables, so they can be set on the host. 

I believe this is the best way to do this, but totally open to suggestions if there is something better I should be doing @mark-cooper.